### PR TITLE
Adjust memory handling

### DIFF
--- a/tests/pytest/pybind11_cuda_array_interface_test.py
+++ b/tests/pytest/pybind11_cuda_array_interface_test.py
@@ -17,3 +17,13 @@ def test_saxpy_kernel():
 
     cp.testing.assert_allclose(s1, s2)
     cp.testing.assert_allclose(s1, s3)
+
+
+def test_sendreceive():
+    cupy_test_array = cp.array([41.0, 62.0, 98.0], dtype=cp.float32)
+    numpy_test_array = cp.asnumpy(cupy_test_array)
+    returned_cupy_array = pycai.receive_and_return_cuda_array_interface(cupy_test_array)
+
+    assert hasattr(returned_cupy_array, "__cuda_array_interface__")
+
+    np.testing.assert_allclose(numpy_test_array, cp.asnumpy(returned_cupy_array))

--- a/tests/sources/gtest_pybind11_cuda_array_interface.cpp
+++ b/tests/sources/gtest_pybind11_cuda_array_interface.cpp
@@ -29,12 +29,10 @@ TEST(CudaArrayInterface, SendAndReceive) {
     py::list lst = py::cast(std::vector<int>({1, 2, 3, 4, 5}));
     py::object cupy_array = cp.attr("array")(lst).attr("astype")("int32");
 
-    py::object result = m.attr("sendandreceive")(cupy_array);
+    py::object received_cupy_array = m.attr("sendandreceive")(cupy_array);
 
     // Check if the returned object has __cuda_array_interface__
-    ASSERT_TRUE(py::hasattr(result, "__cuda_array_interface__"));
-
-    py::object received_cupy_array = cp.attr("asarray")(result);
+    ASSERT_TRUE(py::hasattr(received_cupy_array, "__cuda_array_interface__"));
 
     py::array_t<int> received_numpy_array = cp.attr("asnumpy")(received_cupy_array).cast<py::array_t<int>>();
     py::array_t<int> sent_numpy_array = cp.attr("asnumpy")(cupy_array).cast<py::array_t<int>>();

--- a/tests/sources/pytest_pybind11_cuda_array_interface.cpp
+++ b/tests/sources/pytest_pybind11_cuda_array_interface.cpp
@@ -11,7 +11,7 @@ void saxpy(cai::cuda_array_t s, cai::cuda_array_t x, cai::cuda_array_t y, int a)
     auto x_ptr = x.get_compatible_typed_pointer<float>();
     auto y_ptr = y.get_compatible_typed_pointer<float>();
 
-    call_saxpy(s_ptr, x_ptr, y_ptr, a, s.size_of_shape());
+    call_saxpy(s_ptr, x_ptr, y_ptr, a, static_cast<int>(s.size_of_shape()));
 }
 
 cai::cuda_array_t receive_and_return_cuda_array_interface(cai::cuda_array_t s) {


### PR DESCRIPTION
This PR partly addresses issue #1.  The `cuda_memory_handle` has been adjusted to basically pass the ownership back to Python if a `cuda_array_t` arrives from Python. Preparation for created `cuda_array_t` objects on the c++ side have been added to the `cuda_memory_handle` and the `cast` function of the `type_caster`.

A follow up PR to implement a constructor for `cuda_array_t` should be made.