### PR TITLE
Respect readonly

### DIFF
--- a/include/pybind11_cuda_array_interface/pybind11_cuda_array_interface.hpp
+++ b/include/pybind11_cuda_array_interface/pybind11_cuda_array_interface.hpp
@@ -15,6 +15,7 @@
 #include <pybind11/stl.h>
 
 #include <functional>
+#include <iostream>
 
 #include <cuda.h>
 
@@ -58,13 +59,20 @@ namespace cai {
 
             // Constructor for C++-created objects (default deleter)
             cuda_memory_handle(CUdeviceptr ptr)
-                : ptr(ptr), deleter([](CUdeviceptr ptr) { cuMemFree(ptr); }) {}
+                : ptr(ptr), deleter([](CUdeviceptr ptr) {CUresult result = cuMemFree(ptr);
+                                                         if (result == CUDA_ERROR_INVALID_VALUE) {
+                                                             std::cout << "cuMemFree was called on a null/uninitialised pointer\n";
+                                                         }
+                                                         checkCudaErrors(result);
+                                                        }
+                                   ) {}
 
             // Constructor for Python-created objects (explicit do-nothing deleter)
             cuda_memory_handle(CUdeviceptr ptr, std::function<void(CUdeviceptr)> deleter)
                 : ptr(ptr), deleter(deleter) {}
 
             friend struct cuda_array_t;
+            friend class CudaArrayInterfaceTest;
             friend struct py::detail::type_caster<cuda_array_t>;
 
         public:
@@ -94,7 +102,7 @@ namespace cai {
             }
 
             template <typename T>
-            void check_dtype() {
+            void check_dtype() const {
                 py::dtype expected_dtype = py::dtype::of<T>();
                 py::dtype dt(this->typestr);
 
@@ -110,6 +118,7 @@ namespace cai {
 
             cuda_array_t() {};
 
+            friend class CudaArrayInterfaceTest;
             friend struct py::detail::type_caster<cuda_array_t>;
 
         public:
@@ -188,11 +197,11 @@ public:
 
         //Extract the data key from the cuda array dict
         py::tuple data = iface_dict["data"].cast<py::tuple>();
-        CUdeviceptr inputPtr = data[0].cast<CUdeviceptr>();
-        CUdeviceptr devicePtr;
-        checkCudaErrors(cuPointerGetAttribute(&devicePtr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, inputPtr));
+        CUdeviceptr inputptr = data[0].cast<CUdeviceptr>();
+        CUdeviceptr deviceptr;
+        checkCudaErrors(cuPointerGetAttribute(&deviceptr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, inputptr));
 
-        value.handle = cai::cuda_memory_handle::make_shared_handle(devicePtr, [](CUdeviceptr){});
+        value.handle = cai::cuda_memory_handle::make_shared_handle(deviceptr, [](CUdeviceptr){});
 
         value.readonly = data[1].cast<bool>();
 

--- a/tests/sources/gtest_pybind11_cuda_array_interface.cpp
+++ b/tests/sources/gtest_pybind11_cuda_array_interface.cpp
@@ -7,21 +7,103 @@
 
 namespace py = pybind11;
 
+class PythonEnvironment : public ::testing::Environment {
+    public:
+        ~PythonEnvironment() override = default;
+
+        void SetUp() override {
+            py::initialize_interpreter();
+        }
+
+        void TearDown() override {
+            py::finalize_interpreter();
+        }
+};
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new PythonEnvironment);
+    return RUN_ALL_TESTS();
+}
+
 inline py::module create_module(const std::string& module_name) {
     return py::module_::create_extension_module(module_name.c_str(), nullptr, new py::module_::module_def);
 }
 
-inline const cai::cuda_array_t& send_and_receive_cuda_array_interface(const cai::cuda_array_t& ca)
-{
-    return ca;
+namespace cai {
+
+    inline const cuda_array_t& send_and_receive_cuda_array_interface(const cuda_array_t& ca)
+    {
+        return ca;
+    }
+
+    class CudaArrayInterfaceTest : public ::testing::Test {
+        protected:
+            // The test class is declared as a friend inside cuda_array_t and cuda_memory_handle.
+            CUdevice device;
+            CUcontext context;
+            CUdeviceptr deviceptr;
+
+            void SetUp() override {
+                checkCudaErrors(cuInit(0));
+                checkCudaErrors(cuDeviceGet(&device, 0));
+                checkCudaErrors(cuCtxCreate(&context, 0, device));
+            }
+
+            void TearDown() override {
+                checkCudaErrors(cuCtxDestroy(context));
+            }
+
+            void allocate_deviceptr(size_t size) {
+                checkCudaErrors(cuMemAlloc(&deviceptr, size));
+            }
+
+            cuda_array_t create_cuda_array(bool readonly = false) {
+                allocate_deviceptr(1024 * sizeof(float));
+                cuda_array_t arr;
+                arr.handle = cuda_memory_handle::make_shared_handle(deviceptr);
+                arr.readonly = readonly;
+                arr.typestr = "<f4";  // Assuming float corresponds to "<f4"
+                arr.shape = {5};
+                arr.version = 3;
+                return arr;
+            }
+    };
+
+}
+
+using cai::CudaArrayInterfaceTest;
+
+TEST_F(CudaArrayInterfaceTest, CompatibleTypeNonReadOnly) {
+    cai::cuda_array_t arr = create_cuda_array();
+    EXPECT_NO_THROW(arr.get_compatible_typed_pointer<float>());
+}
+
+TEST_F(CudaArrayInterfaceTest, CompatibleTypeReadOnly) {
+    cai::cuda_array_t arr = create_cuda_array(true);
+    EXPECT_THROW(arr.get_compatible_typed_pointer<float>(), std::runtime_error);
+}
+
+TEST_F(CudaArrayInterfaceTest, InCompatibleTypeReadOnly) {
+    const cai::cuda_array_t arr = create_cuda_array();
+    EXPECT_NO_THROW(arr.get_compatible_typed_pointer<float>());
+}
+
+TEST_F(CudaArrayInterfaceTest, InCompatibleTypeReadOnlySaveConst) {
+    const cai::cuda_array_t arr = create_cuda_array(true);
+    EXPECT_NO_THROW(arr.get_compatible_typed_pointer<float>());
+}
+
+TEST_F(CudaArrayInterfaceTest, IncompatibleType) {
+    cai::cuda_array_t arr = create_cuda_array();
+    EXPECT_THROW(arr.get_compatible_typed_pointer<int>(), std::runtime_error);
 }
 
 TEST(CudaArrayInterface, SendAndReceive) {
-    py::scoped_interpreter guard;
 
     auto m = create_module("test");
 
-    m.def("sendandreceive", &send_and_receive_cuda_array_interface);
+    m.def("sendandreceive", &cai::send_and_receive_cuda_array_interface);
 
     py::module cp = py::module::import("cupy");
     py::module np = py::module::import("numpy");


### PR DESCRIPTION
The `__cuda_array_interface__` has a field: `data` which contains the pointer and a `readonly` boolean. While this is impractical and hard to match to c++ since it has to enforce constness at runtime and not compile time, an approach taken in this PR is simply to overload the method to extract the typed_pointer `const` or `non-const` depending on if the `cuda_array_t` was declared `const` or `non-const` by checking the value of `readonly`. Nevertheless, this flag is not respected by e.g. CuPy or Numba (the ones who defined the `__cuda_array_interface__`) because it would be highly untrivial to manage the constness at runtime for all possible operations.

This PR can at least provide the user with a hint that we expect the delivered `cuda_array_t`'s to contain a pointer to constant data.

closes #9 