### PR TITLE
Constructor for cuda_array_t

### DIFF
--- a/include/pybind11_cuda_array_interface/pybind11_cuda_array_interface.hpp
+++ b/include/pybind11_cuda_array_interface/pybind11_cuda_array_interface.hpp
@@ -59,13 +59,7 @@ namespace cai {
 
             // Constructor for C++-created objects (default deleter)
             cuda_memory_handle(void* ptr)
-                : ptr(ptr), deleter([](void* ptr) {cudaError_t result = cudaFree(ptr);
-                                                         if (result == cudaErrorInvalidValue) {
-                                                             std::cout << "cudaFree was called on a null/uninitialised pointer\n";
-                                                         }
-                                                         checkCudaErrors(result);
-                                                        }
-                                   ) {}
+                : ptr(ptr), deleter([](void* ptr) {checkCudaErrors(cudaFree(ptr));}) {}
 
             // Constructor for Python-created objects (explicit do-nothing deleter)
             cuda_memory_handle(void* ptr, std::function<void(void*)> deleter)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,7 +65,6 @@ if(BUILD_GTESTS)
                 ${GTEST_BOTH_LIBRARIES}
                 pybind11::pybind11
                 pybind11::embed
-                cuda
                 CUDA::cudart
     )
     target_include_directories(${EXECNAME} PRIVATE
@@ -84,7 +83,7 @@ if(BUILD_PYTESTS)
     set(MODULENAME pycai)
     set(CPPSOURCES sources/pytest_pybind11_cuda_array_interface.cpp)
     set(CUSOURCES sources/test_kernels.cu)
-    set(LIBS Python3::Python pybind11::pybind11 pybind11::embed cuda CUDA::cudart)
+    set(LIBS Python3::Python pybind11::pybind11 pybind11::embed CUDA::cudart)
 
     # TODO: The following module from pybind11 does not respect the CMAKE_CUDA_ARCHITECTURES
     # variable which handles which archs to build and link to. This results in missing linking

--- a/tests/sources/gtest_pybind11_cuda_array_interface.cpp
+++ b/tests/sources/gtest_pybind11_cuda_array_interface.cpp
@@ -41,22 +41,14 @@ namespace cai {
     class CudaArrayInterfaceTest : public ::testing::Test {
         protected:
             // The test class is declared as a friend inside cuda_array_t<T> and cuda_memory_handle<T>.
-            CUdevice device;
-            CUcontext context;
-            CUdeviceptr deviceptr;
+            void* deviceptr;
 
-            void SetUp() override {
-                checkCudaErrors(cuInit(0));
-                checkCudaErrors(cuDeviceGet(&device, 0));
-                checkCudaErrors(cuCtxCreate(&context, 0, device));
-            }
+            void SetUp() override {}
 
-            void TearDown() override {
-                checkCudaErrors(cuCtxDestroy(context));
-            }
+            void TearDown() override {}
 
             void allocate_deviceptr(size_t size) {
-                checkCudaErrors(cuMemAlloc(&deviceptr, size));
+                checkCudaErrors(cudaMalloc(&deviceptr, size));
             }
 
             template <typename T>

--- a/tests/sources/gtest_pybind11_cuda_array_interface.cpp
+++ b/tests/sources/gtest_pybind11_cuda_array_interface.cpp
@@ -32,14 +32,15 @@ inline py::module create_module(const std::string& module_name) {
 
 namespace cai {
 
-    inline const cuda_array_t& send_and_receive_cuda_array_interface(const cuda_array_t& ca)
+    template <typename T>
+    inline const cuda_array_t<T>& send_and_receive_cuda_array_interface(const cuda_array_t<T>& ca)
     {
         return ca;
     }
 
     class CudaArrayInterfaceTest : public ::testing::Test {
         protected:
-            // The test class is declared as a friend inside cuda_array_t and cuda_memory_handle.
+            // The test class is declared as a friend inside cuda_array_t<T> and cuda_memory_handle<T>.
             CUdevice device;
             CUcontext context;
             CUdeviceptr deviceptr;
@@ -58,12 +59,13 @@ namespace cai {
                 checkCudaErrors(cuMemAlloc(&deviceptr, size));
             }
 
-            cuda_array_t create_cuda_array(bool readonly = false) {
-                allocate_deviceptr(1024 * sizeof(float));
-                cuda_array_t arr;
-                arr.handle = cuda_memory_handle::make_shared_handle(deviceptr);
+            template <typename T>
+            cuda_array_t<T> create_cuda_array(bool readonly = false) {
+                allocate_deviceptr(1024 * sizeof(T));
+                cuda_array_t<T> arr;
+                arr.handle = cuda_memory_handle<T>::make_shared_handle(deviceptr);
                 arr.readonly = readonly;
-                arr.typestr = "<f4";  // Assuming float corresponds to "<f4"
+                arr.typestr = py::format_descriptor<T>::format();
                 arr.shape = {5};
                 arr.version = 3;
                 return arr;
@@ -75,35 +77,30 @@ namespace cai {
 using cai::CudaArrayInterfaceTest;
 
 TEST_F(CudaArrayInterfaceTest, CompatibleTypeNonReadOnly) {
-    cai::cuda_array_t arr = create_cuda_array();
-    EXPECT_NO_THROW(arr.get_compatible_typed_pointer<float>());
+    auto arr = create_cuda_array<float>();
+    EXPECT_NO_THROW(arr.get_compatible_typed_pointer());
 }
 
 TEST_F(CudaArrayInterfaceTest, CompatibleTypeReadOnly) {
-    cai::cuda_array_t arr = create_cuda_array(true);
-    EXPECT_THROW(arr.get_compatible_typed_pointer<float>(), std::runtime_error);
+    auto arr = create_cuda_array<float>(true);
+    EXPECT_THROW(arr.get_compatible_typed_pointer(), std::runtime_error);
 }
 
 TEST_F(CudaArrayInterfaceTest, InCompatibleTypeReadOnly) {
-    const cai::cuda_array_t arr = create_cuda_array();
-    EXPECT_NO_THROW(arr.get_compatible_typed_pointer<float>());
+    const auto arr = create_cuda_array<float>();
+    EXPECT_NO_THROW(arr.get_compatible_typed_pointer());
 }
 
 TEST_F(CudaArrayInterfaceTest, InCompatibleTypeReadOnlySaveConst) {
-    const cai::cuda_array_t arr = create_cuda_array(true);
-    EXPECT_NO_THROW(arr.get_compatible_typed_pointer<float>());
-}
-
-TEST_F(CudaArrayInterfaceTest, IncompatibleType) {
-    cai::cuda_array_t arr = create_cuda_array();
-    EXPECT_THROW(arr.get_compatible_typed_pointer<int>(), std::runtime_error);
+    const auto arr = create_cuda_array<float>(true);
+    EXPECT_NO_THROW(arr.get_compatible_typed_pointer());
 }
 
 TEST(CudaArrayInterface, SendAndReceive) {
 
     auto m = create_module("test");
 
-    m.def("sendandreceive", &cai::send_and_receive_cuda_array_interface);
+    m.def("sendandreceive", &cai::send_and_receive_cuda_array_interface<float>);
 
     py::module cp = py::module::import("cupy");
     py::module np = py::module::import("numpy");

--- a/tests/sources/pytest_pybind11_cuda_array_interface.cpp
+++ b/tests/sources/pytest_pybind11_cuda_array_interface.cpp
@@ -23,7 +23,11 @@ cai::cuda_array_t<T> receive_and_return_cuda_array_interface(cai::cuda_array_t<T
 
 template <typename T>
 cai::cuda_array_t<T> return_cuda_array_interface() {
-    cai::cuda_array_t<T> s({5});
+    std::vector<T> vec = {1.0, 2.0, 3.0, 4.0, 5.0};
+
+    cai::cuda_array_t<T> s({vec.size()});
+    checkCudaErrors(cudaMemcpy(s.get_compatible_typed_pointer(), vec.data(), vec.size() * sizeof(T), cudaMemcpyHostToDevice));
+
     return s;
 }
 
@@ -35,6 +39,3 @@ PYBIND11_MODULE(pycai, module) {
     module.def("return_cuda_array_interface", &return_cuda_array_interface<float>);
 
 }
-
-//m.def("create_cuda_array", &create_cuda_array, py::return_value_policy::take_ownership, py::keep_alive<0, 1>());
-

--- a/tests/sources/pytest_pybind11_cuda_array_interface.cpp
+++ b/tests/sources/pytest_pybind11_cuda_array_interface.cpp
@@ -5,25 +5,36 @@
 
 #include <iostream>
 
-void saxpy(cai::cuda_array_t s, cai::cuda_array_t x, cai::cuda_array_t y, int a) {
 
-    auto s_ptr = s.get_compatible_typed_pointer<float>();
-    auto x_ptr = x.get_compatible_typed_pointer<float>();
-    auto y_ptr = y.get_compatible_typed_pointer<float>();
+template <typename T>
+void saxpy(cai::cuda_array_t<T> s, cai::cuda_array_t<T> x, cai::cuda_array_t<T> y, int a) {
+
+    auto s_ptr = s.get_compatible_typed_pointer();
+    auto x_ptr = x.get_compatible_typed_pointer();
+    auto y_ptr = y.get_compatible_typed_pointer();
 
     call_saxpy(s_ptr, x_ptr, y_ptr, a, static_cast<int>(s.size_of_shape()));
 }
 
-cai::cuda_array_t receive_and_return_cuda_array_interface(cai::cuda_array_t s) {
+template <typename T>
+cai::cuda_array_t<T> receive_and_return_cuda_array_interface(cai::cuda_array_t<T> s) {
+    return s;
+}
+
+template <typename T>
+cai::cuda_array_t<T> return_cuda_array_interface() {
+    cai::cuda_array_t<T> s({5});
     return s;
 }
 
 PYBIND11_MODULE(pycai, module) {
     module.doc() = "Test module for __cuda_array_interface__";
 
-    module.def("saxpy", &saxpy);
-    module.def("receive_and_return_cuda_array_interface", &receive_and_return_cuda_array_interface);
+    module.def("saxpy", &saxpy<float>);
+    module.def("receive_and_return_cuda_array_interface", &receive_and_return_cuda_array_interface<float>);
+    module.def("return_cuda_array_interface", &return_cuda_array_interface<float>);
 
 }
 
 //m.def("create_cuda_array", &create_cuda_array, py::return_value_policy::take_ownership, py::keep_alive<0, 1>());
+


### PR DESCRIPTION
This PR grew a bit out of hand and I will stop here having made three rather large changes/additions.

1) Changed from the driverAPI to the runtimeAPI. Most Python libraries dealing with cuda wrap the runtimeAPI so it makes sense to use that for the interface code as well.

2) Made `cuda_array_t` a template to easier track the C++ type and how we relate that to the dtype from Python.

3) Tidied the treatment of the `capsule` for lifetime and pointer handling when returning a `cuda_array_t` created in Python.

4) Added a constructor for `cuda_array_t` such that is it possible to create an instance of it without having to receive one from Python first.

As to not grow this PR further, I leave tests, for now, to follow in a later PR.

closes #1 