### PR TITLE
Caching cuda for github actions

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -127,3 +127,6 @@ jobs:
         -isystem `python3 -c "import pybind11; print(pybind11.get_include())"` \
         -isystem `python3-config --includes` \
         -isystem /usr/src/googletest/googletest/include/
+
+    - name: Change permissions before cache cleanup
+      run: sudo chown -R $(whoami):$(whoami) /var/cache/apt/archives

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -55,6 +55,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Cache CUDA toolkit packages
+      id: cache-cuda
+      uses: actions/cache@v2
+      with:
+        path: /var/cache/apt/archives
+        key: cuda-${{ runner.os }}-${{ hashFiles('.github/workflows/linting.yaml') }}
+        restore-keys: |
+          cuda-${{ runner.os }}-
+
     - name: Install cuda
       run: |
         sudo apt-get update -y

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -46,6 +46,7 @@ jobs:
 
     - name: Run the linting tools
       run: |
+        source venv/bin/activate
         python linting/check_python_linting.py
 
 
@@ -55,6 +56,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+
     - name: Change permissions for caching
       run: sudo chown -R $(whoami):$(whoami) /var/cache/apt/archives
 
@@ -78,16 +89,6 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y --no-install-recommends \
         clang-format-14 clang-tidy-14 clang-14 g++-12 googletest
-
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
 
     - name: Create Python venv
       run: |

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -55,6 +55,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Change permissions for caching
+      run: sudo chown -R $(whoami):$(whoami) /var/cache/apt/archives
+
     - name: Cache CUDA toolkit packages
       id: cache-cuda
       uses: actions/cache@v2

--- a/linting/check_python_linting.py
+++ b/linting/check_python_linting.py
@@ -63,6 +63,7 @@ class Linter:
             print("\nLinting succeeded 🎉\n")
         else:
             print("\nLinting failed 🔗‍💥\n")
+            sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Installing the cuda toolkit every time is costly. This PR aims to cache the .deb file at least.

