### PR TITLE
Skip testing with test pypi after merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,6 +134,7 @@ jobs:
 
   test_upload_pypi:
     name: Upload pycai to Test-PyPI
+    if: github.ref != 'refs/heads/main'
     needs: [build_and_test, packaging]
     runs-on: ubuntu-latest
 
@@ -160,6 +161,7 @@ jobs:
 
   test_pypi_package:
     name: Test pycai from TestPyPI
+    if: github.ref != 'refs/heads/main'
     needs: [test_upload_pypi]
     runs-on: self-hosted
     strategy:


### PR DESCRIPTION
It is not feasible to do two uploads to test_pypi for the same code, so skip the upload after merge.